### PR TITLE
.binstar.yml for CI builds

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -14,8 +14,6 @@ before_script:
 - echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
 
-build_targets:
-- conda
 engine:
 - python
 script:
@@ -23,8 +21,8 @@ script:
 install_channels:
 - defaults
 - python
-package: ProtoCI
+package: protoci
 platform:
 - osx-64
 - linux-64
-user: psteinberg
+

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -5,11 +5,13 @@ after_script:
 after_success:
 - echo "ProtoCI BUILD SUCCESS"
 before_script:
-- echo "Prepare to install networkx...."
-- conda install networkx PyYAML requests
+- echo "Prepare to install networkx PyYAML requests jinja2...."
+- conda install networkx PyYAML requests jinja2
+- echo "Prepare to clone conda and conda-build for metadata reading..."
 - git clone https://github.com/conda/conda-build
 - git clone https://github.com/conda/conda
 - export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
+- echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
 
 build_targets:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -14,7 +14,8 @@ before_script:
 - echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
 - echo 'Try to get m4'
-- conda install m4 || wget ftp://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz && tar -xvzf m4-1.4.10.tar.gz && cd m4-1.4.10 && ./configure --prefix=/usr/local/m4 && make && cd ..
+- install_m4() { wget ftp://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz && tar -xvzf m4-1.4.10.tar.gz && cd m4-1.4.10 && ./configure --prefix=/usr/local/m4 && make && cd ..; }
+- conda install m4 || install_m4
 
 
 engine:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,28 @@
+after_failure:
+- echo "After failure message!"
+after_script:
+- echo "ProtoCI build was a:$BINSTAR_BUILD_RESULT" | tee artifact1.txt
+after_success:
+- echo "ProtoCI BUILD SUCCESS"
+before_script:
+- echo "Prepare to install networkx...."
+- conda install networkx PyYAML requests
+- git clone https://github.com/conda/conda-build
+- git clone https://github.com/conda/conda
+- export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
+- echo $PYTHONPATH
+
+build_targets:
+- conda
+engine:
+- python
+script:
+ - python build2.py ./ -buildall
+install_channels:
+- defaults
+- python
+package: ProtoCI
+platform:
+- osx-64
+- linux-64
+user: psteinberg

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -13,6 +13,9 @@ before_script:
 - export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
 - echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
+- echo 'Try to get m4'
+- conda install m4 || wget ftp://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz && tar -xvzf m4-1.4.10.tar.gz && cd m4-1.4.10 && ./configure --prefix=/usr/local/m4 && make && cd ..
+
 
 engine:
 - python


### PR DESCRIPTION
This PR adds a .binstar.yml to control remote CI builds.  There was a problem where the build workers were not able to import root packages, such as conda-build, so the `before_script` action is added in the .binstar.yml to clone conda and conda-build in the current directory, add them to the PYTHONPATH, so that build2.py could `from conda_build.metadata import MetaData`

Adjust the username in the .binstar.yml when used.
