### PR TITLE
Psteinberg/split builds

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -14,8 +14,6 @@ before_script:
 - echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
 
-build_targets:
-- conda
 engine:
 - python
 script:
@@ -23,8 +21,8 @@ script:
 install_channels:
 - defaults
 - python
-package: ProtoCI
+package: protoci
 platform:
 - osx-64
 - linux-64
-user: psteinberg
+

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -5,11 +5,13 @@ after_script:
 after_success:
 - echo "ProtoCI BUILD SUCCESS"
 before_script:
-- echo "Prepare to install networkx...."
-- conda install networkx PyYAML requests
+- echo "Prepare to install networkx PyYAML requests jinja2...."
+- conda install networkx PyYAML requests jinja2
+- echo "Prepare to clone conda and conda-build for metadata reading..."
 - git clone https://github.com/conda/conda-build
 - git clone https://github.com/conda/conda
 - export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
+- echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
 
 build_targets:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -14,7 +14,8 @@ before_script:
 - echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
 - echo 'Try to get m4'
-- conda install m4 || wget ftp://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz && tar -xvzf m4-1.4.10.tar.gz && cd m4-1.4.10 && ./configure --prefix=/usr/local/m4 && make && cd ..
+- install_m4() { wget ftp://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz && tar -xvzf m4-1.4.10.tar.gz && cd m4-1.4.10 && ./configure --prefix=/usr/local/m4 && make && cd ..; }
+- conda install m4 || install_m4
 
 
 engine:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,28 @@
+after_failure:
+- echo "After failure message!"
+after_script:
+- echo "ProtoCI build was a:$BINSTAR_BUILD_RESULT" | tee artifact1.txt
+after_success:
+- echo "ProtoCI BUILD SUCCESS"
+before_script:
+- echo "Prepare to install networkx...."
+- conda install networkx PyYAML requests
+- git clone https://github.com/conda/conda-build
+- git clone https://github.com/conda/conda
+- export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
+- echo $PYTHONPATH
+
+build_targets:
+- conda
+engine:
+- python
+script:
+ - python build2.py ./ -buildall
+install_channels:
+- defaults
+- python
+package: ProtoCI
+platform:
+- osx-64
+- linux-64
+user: psteinberg

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -21,12 +21,11 @@ before_script:
 engine:
 - python
 script:
- - python build2.py ./ -buildall
+ - python build2.py ./ build -buildall
 install_channels:
 - defaults
 - python
 package: protoci
 platform:
-- osx-64
 - linux-64
 

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -13,6 +13,9 @@ before_script:
 - export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
 - echo "PYTHONPATH below should include ./conda and ./conda-build"
 - echo $PYTHONPATH
+- echo 'Try to get m4'
+- conda install m4 || wget ftp://ftp.gnu.org/gnu/m4/m4-1.4.10.tar.gz && tar -xvzf m4-1.4.10.tar.gz && cd m4-1.4.10 && ./configure --prefix=/usr/local/m4 && make && cd ..
+
 
 engine:
 - python

--- a/build2.py
+++ b/build2.py
@@ -79,12 +79,14 @@ def construct_graph(directory):
             g.add_edge(name, k)
 
     return g
+
 def successors_iter(g, s, nodes):
     for s in g.successors(s):
         nodes.add(s)
         for s in tuple(successors_iter(g, s, nodes)):
             nodes.add(s)
     return nodes
+
 def coalesce(hi_level_builds, targetnum):
     coalesced = defaultdict(lambda: [])
     counts = [(k, len(v)) for k, v in hi_level_builds.items()]

--- a/build2.py
+++ b/build2.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from collections import defaultdict
+import json
 import os
 import subprocess
 
@@ -8,6 +10,7 @@ import networkx as nx
 from conda_build.metadata import parse, MetaData
 
 CONDA_BUILD_CACHE=os.environ.get("CONDA_BUILD_CACHE")
+
 
 def read_recipe(path):
     return MetaData(path)
@@ -40,23 +43,23 @@ def format_deps(deps):
 
 def get_build_deps(recipe):
     return format_deps(recipe.get_value('requirements/build'))
-    
+
 def construct_graph(directory):
     '''
     Construct a directed graph of dependencies from a directory of recipes
-    
+
     Annotate dependencies that don't have recipes in that directory
     '''
-    
+
     g = nx.DiGraph()
     build_numbers = {}
     directory = os.path.abspath(directory)
     assert os.path.isdir(directory)
-    
+
     # get all immediate subdirectories
     recipe_dirs = next(os.walk(directory))[1]
     recipe_dirs = set(x for x in recipe_dirs if not x.startswith('.'))
-    
+
     for rd in recipe_dirs:
         recipe_dir = os.path.join(directory, rd)
         try:
@@ -64,14 +67,57 @@ def construct_graph(directory):
             name = pkg.name()
         except:
             continue
-        
+
         # add package (in case it has no build deps)
         g.add_node(name, meta=describe_meta(pkg), recipe=recipe_dir)
         for k, d in get_build_deps(pkg).iteritems():
             g.add_edge(name, k)
 
     return g
-    
+
+def split_graph(g, target_num, split_file):
+    g = g.copy()
+    packages_covered = defaultdict(lambda:0)
+    degrees = dict(g.degree_iter())
+    def successors_iter(g, s, nodes):
+        for s in g.successors(s):
+            nodes.add(s)
+            for s in tuple(successors_iter(g, s, nodes)):
+                nodes.add(s)
+        return nodes
+    def coalesce(hi_level_builds, target_num):
+        coalesced = defaultdict(lambda: [])
+        counts = [(k, len(v)) for k, v in hi_level_builds.items()]
+        group = []
+        for key, count in sorted(counts, key=lambda x:x[1]):
+            group.append(hi_level_builds[key] + [key])
+            if sum(map(len, group)) >= target_num:
+                for g in group:
+                    if g == key:
+                        continue
+                    coalesced[key] += [gi for gi in g if gi not in coalesced[key] and gi != key]
+                group = []
+        if group:
+            for g in group:
+                coalesced[key] += [gi for gi in g if gi not in coalesced[key] and gi != key]
+        return coalesced
+
+    hi_level_builds = {}
+    for hi_level in nx.topological_sort(g):
+        if hi_level in packages_covered:
+            continue
+        succ = tuple(successors_iter(g, hi_level, set()))
+        for s in succ:
+            packages_covered[s] += 1
+        packages_covered[hi_level] += 1
+        succ_order = sorted(((s, degrees[s]) for s in succ),
+                            key=lambda x:-x[1])
+        hi_level_builds[hi_level] = [_[0] for _ in succ_order]
+    hi_level_builds = coalesce(hi_level_builds, target_num)
+    with open(split_file, 'w') as f:
+        f.write(json.dumps(hi_level_builds))
+    return hi_level_builds
+
 def build_order(graph, packages, level=0):
     '''
     Assumes that packages are in graph
@@ -82,11 +128,11 @@ def build_order(graph, packages, level=0):
     else:
         packages = set(packages)
         tmp_global = graph.subgraph(packages)
-        
+
         if level > 0:
             # for each level, add all deps
             _level = level
-         
+
             currlevel = packages
             while _level > 0:
                 newcurr = set()
@@ -95,21 +141,21 @@ def build_order(graph, packages, level=0):
                     tmp_global.add_edges_from(graph.edges_iter(p))
                 currlevel = newcurr
                 _level -= 1
-                
+
     #copy relevant node data to tmp_global
     for n in tmp_global.nodes_iter():
         tmp_global.node[n] = graph.node[n]
-        
+
     return tmp_global, nx.topological_sort(tmp_global, reverse=True)
 
-    
+
 def check_built(package):
     '''Check to see if package is already built'''
     print("checking if package exists")
     if os.path.exists(os.path.join(CONDA_BUILD_CACHE, package.pkg_fn())):
         return True
     return False
-    
+
 
 def make_deps(graph, package, dry=False, extra_args='', level=0):
     g, order = build_order(graph, package, level=level)
@@ -126,7 +172,7 @@ def make_deps(graph, package, dry=False, extra_args='', level=0):
             except:
                 failed.append(pkg)
                 continue
-    
+
     print("The following packages failed to build: ")
     print(', '.join(failed))
 
@@ -145,42 +191,58 @@ def make_pkg(package, dry=False, extra_args=''):
             print("Build failed with errorcode: ", e.returncode)
             print(e)
             raise e
-    
+
 def recompile(graph, package, dry=False):
     """ Recompile packages that depend on package against new version of package """
-    
+
     # no need to order packages.
     for p in graph.predecessors(package):
         if graph.node[p].get('meta', ''):
             make_pkg(graph.node[p]['meta'], dry=dry)
-    
+
 
 
 if __name__ == "__main__":
     import sys
     import argparse
-    
+
     p = argparse.ArgumentParser()
-    build_pkgs = p.add_mutually_exclusive_group()
+    p.add_argument("path", default='.')
+    subp = p.add_subparsers(help="Build or split to make json of package "
+                                 "order/grouping. \n\tChoices: %(choices)s")
+    build_parser = subp.add_parser('build')
+    build_pkgs = build_parser.add_mutually_exclusive_group()
     build_pkgs.add_argument("-build", action='append', default=[])
     build_pkgs.add_argument("-buildall", action='store_true')
-    p.add_argument("-dry", action='store_true', default=False)
-    p.add_argument("-api", action='store_true', dest='recompile', default=False)
-    p.add_argument("-args", action='store', dest='cbargs', default='')
-    p.add_argument("-l", type=int, action='store', dest='level', default=0)
-    p.add_argument("path", default='.')
+    build_parser.add_argument("-from-json-file", type=str)
+    build_parser.add_argument("-from-json-key", type=str)
+    build_parser.add_argument("-dry", action='store_true', default=False)
+    build_parser.add_argument("-api", action='store_true', dest='recompile', default=False)
+    build_parser.add_argument("-args", action='store', dest='cbargs', default='')
+    build_parser.add_argument("-l", type=int, action='store', dest='level', default=0)
+    split_parser = subp.add_parser('split')
+    split_parser.add_argument('-t','--targetnum', type=int, default=10, help="How many packages in one anaconda build submission typically.")
+    split_parser.add_argument('-s','--split-files',type=str)
     args = p.parse_args()
-    
-    print("%s" % (args.build))
-    print("-------------------------------")
-    
-    g = construct_graph(args.path)
 
+    print("%s" % (getattr(args,'build','')))
+    print("-------------------------------")
+
+    g = construct_graph(args.path)
+    if args.split_files is not None:
+        split_graph(g, args.targetnum, args.split_files)
+        print("See ", args.split_files, 'for split packages')
+        sys.exit(0)
     try:
         if args.buildall:
             args.build = None
+            if args.from_json_keys:
+                with open(args.from_json_key[0]) as f:
+                    args.build = [args.from_json_key[1]] +  \
+                                 json.load(f)[args.from_json_key[1]]
+
         make_deps(g, args.build, args.dry, extra_args=args.cbargs, level=args.level)
-        
+
         if args.recompile:
             print("\nRecompiling due to API change:")
             print(recompile(g, args.build, args.dry))


### PR DESCRIPTION
Makes separate subparsers, one for the build of packages ('build') and one for the splitting of packages into distinct trees of a target size ('split').

Here is an example of the split action that we would run before submitting builds to anaconda build:

``````
$ python build2.py ./ split -t 5 -s somejs.js && cat somejs.js
{"libnetcdf": ["curl", "cmake", "hdf5", "zlib"], "pysam": ["python", "cython", "cmake", "zlib"]}```

$ python build2.py ./ split -t 10 -s somejs.js && cat somejs.js
{"pysam": ["curl", "cmake", "hdf5", "zlib", "libnetcdf", "python", "cython"]}
``````

`-t` is the target number of packages per group, `-s` is the name of a file to save the splits in a json dict

The other usage pattern is build to actually do the build (as would be called from .binstar.yml):

```
# to build all files in dir ./
python build2.py ./ build -buildall
```

```
# to build only the hdf5 package
python build2.py ./ build -build hdf5
```

```
# to build all the packages in a key of a json created by the split method mentioned above
# libnetcdf must be a key in somejs.js
python build2.py ./ build -json-file-key somejs.js libnetcdf
```
