### PR TITLE
Psteinberg/help submit

### DIFF
--- a/binstar_template.yml
+++ b/binstar_template.yml
@@ -8,10 +8,12 @@ before_script:
 - echo "Prepare to install networkx PyYAML requests jinja2...."
 - conda install networkx PyYAML requests jinja2
 - echo "Prepare to clone conda and conda-build for metadata reading..."
-- git clone https://github.com/conda/conda-build
-- git clone https://github.com/conda/conda
-- export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
-- echo "PYTHONPATH below should include ./conda and ./conda-build"
+- mkdir conda_tmp
+# avoid conflict with conda or conda-build dirs if already there
+- git clone https://github.com/conda/conda-build conda_tmp/conda-build
+- git clone https://github.com/conda/conda conda_tmp/conda
+- export PYTHONPATH=$PYTHONPATH:./conda_tmp/conda-build:./conda_tmp/conda
+- echo "PYTHONPATH below should include ./conda_tmp"
 - echo $PYTHONPATH
 
 engine:

--- a/binstar_template.yml
+++ b/binstar_template.yml
@@ -15,6 +15,7 @@ before_script:
 - export PYTHONPATH=$PYTHONPATH:./conda_tmp/conda-build:./conda_tmp/conda
 - echo "PYTHONPATH below should include ./conda_tmp"
 - echo $PYTHONPATH
+- conda install psutil
 
 engine:
 - python
@@ -27,4 +28,5 @@ package: {{PACKAGE}}
 platform:
 {{PLATFORMS}}
 user: {{USER}}
+quiet: True
 

--- a/binstar_template.yml
+++ b/binstar_template.yml
@@ -1,0 +1,28 @@
+after_failure:
+- echo "After failure message!"
+after_script:
+- echo "ProtoCI build was a:$BINSTAR_BUILD_RESULT" | tee artifact1.txt
+after_success:
+- echo "ProtoCI BUILD SUCCESS"
+before_script:
+- echo "Prepare to install networkx PyYAML requests jinja2...."
+- conda install networkx PyYAML requests jinja2
+- echo "Prepare to clone conda and conda-build for metadata reading..."
+- git clone https://github.com/conda/conda-build
+- git clone https://github.com/conda/conda
+- export PYTHONPATH=$PYTHONPATH:./conda-build:./conda
+- echo "PYTHONPATH below should include ./conda and ./conda-build"
+- echo $PYTHONPATH
+
+engine:
+- python
+script:
+ - python build2.py {{BUILD_ARGS}}
+install_channels:
+- defaults
+- python
+package: {{PACKAGE}}
+platform:
+{{PLATFORMS}}
+user: {{USER}}
+

--- a/build2.py
+++ b/build2.py
@@ -215,6 +215,19 @@ def make_pkg(package, dry=False, extra_args=''):
 
 
 def submit_one(args):
+    '''
+    Adjusts binstar_template.yml
+    base on
+        user
+        queue
+        build arguments
+        platforms
+    Comes up with a package name for user
+    Creates package if it doesn't exist
+    Submits package
+    Prints out the command you need to tail the build
+    returns 0 if okay
+    '''
     import jinja2
     js_file, key = args.json_file_key
     with open('binstar_template.yml') as f:
@@ -289,29 +302,41 @@ def cli(parse_this=None):
     build_pkgs = build_parser.add_mutually_exclusive_group()
     build_pkgs.add_argument("-build", action='append', default=[])
     build_pkgs.add_argument("-buildall", action='store_true')
-    build_pkgs.add_argument('-json-file-key', default=[], nargs=2)
-    build_parser.add_argument("-dry", action='store_true', default=False)
-    build_parser.add_argument("-api", action='store_true', dest='recompile', default=False)
+    build_pkgs.add_argument('-json-file-key', default=[], nargs=2,
+                            help="Example: -json-file-key package_tree.js libnetcdf")
+    build_parser.add_argument("-dry", action='store_true', default=False,
+                              help="Dry run")
+    build_parser.add_argument("-api", action='store_true', dest='recompile',
+                              default=False)
     build_parser.add_argument("-args", action='store', dest='cbargs', default='')
-    build_parser.add_argument("-l", type=int, action='store', dest='level', default=0)
-    build_parser.add_argument("-t", action='store_true', dest='t', default=False)
-    build_parser.add_argument("-noautofail", action='store_false', dest='autofail', default=True)
+    build_parser.add_argument("-l", type=int, action='store', dest='level', default=0,
+                              help='Build to level. Ignored with -json-file-key')
+    build_parser.add_argument("-t", action='store_true', dest='t', default=False,
+                              help="Output build times")
+    build_parser.add_argument("-noautofail", action='store_false',
+                              dest='autofail', default=True)
     split_parser = subp.add_parser('split')
-    split_parser.add_argument('-t','--targetnum', type=int, default=10, help="How many packages in one anaconda build submission typically.")
-    split_parser.add_argument('-s','--split-files',type=str,required=True)
+    split_parser.add_argument('-t','--targetnum', type=int,
+                              default=10,
+                              help="How many packages in one anaconda "
+                                   "build submission typically.")
+    split_parser.add_argument('-s','--split-files',type=str,default="package_tree.js")
     submit_parser = subp.add_parser('submit')
     json_read_choice = submit_parser.add_mutually_exclusive_group()
     json_read_choice.add_argument('-json-file-key',
-                                  default=[], nargs=2)
+                                  default=[], nargs=2,
+                                help="Example: -json-file-key package_tree.js libnetcdf")
     json_read_choice.add_argument('-full-json',
                                   type=str,
-                                  help="full path to json of splits")
-    submit_parser.add_argument('-user', default='conda-team')
-    submit_parser.add_argument('-queue', default='build_recipes')
-    submit_parser.add_argument('-dry', action='store_true')
+                                  help="Build all packages named in json of splits")
+    submit_parser.add_argument('-user', default='conda-team',
+                               help="Anaconda username. Default: %(default)s")
+    submit_parser.add_argument('-queue', default='build_recipes',
+                               help="Anaconda build queue. Default: %(default)s")
+    submit_parser.add_argument('-dry', action='store_true', help='Dry run')
     submit_parser.add_argument('-platforms', required=True,
-                               help="osx-64, linux-64 and/or win-64",
-                               default=[],
+                               help="Some of all of %(default)s",
+                               default=['osx-64', 'linux-64','win-64'],
                                action='append')
     if parse_this is None:
         args = p.parse_args()

--- a/build2.py
+++ b/build2.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 
 import argparse
 from collections import defaultdict
+import datetime
 import json
 import psutil
 import os
@@ -392,6 +393,19 @@ def pre_submit_clean_up(args):
             print('Copy', full_file, 'to', target+'_removed')
             shutil.copy(full_file, target + '_removed')
             shutil.copy(full_file, target)
+
+    this_file = os.path.basename(__file__)
+    build2_in_other_dir = os.path.abspath(os.path.join(args.path, this_file))
+    shutil.copy(__file__, build2_in_other_dir)
+    print('Copy',__file__,'to', build2_in_other_dir)
+    package_tree_file = os.path.abspath(args.full_json or args.json_file_key[0])
+    n = datetime.datetime.now()
+    datestr = "_".join(map(str, (n.year, n.month, n.day, n.hour, n.minute, n.second)))
+    branch_name = 'build_' + datestr
+    print('Make a scratch git branch in', os.path.abspath(args.path))
+    subprocess.check_output(['git', 'checkout', '-b', branch_name], cwd=args.path)
+    subprocess.check_output(['git', 'add', build2_in_other_dir, package_tree_file], cwd=args.path)
+    subprocess.check_output(['git', 'commit', '-m', 'commit build2.py and the package json for anaconda-build'], cwd=args.path)
 
 
 def submit_helper(args):

--- a/package_tree.js
+++ b/package_tree.js
@@ -1,1 +1,1 @@
-{"libnetcdf": ["curl", "cmake", "hdf5", "zlib"], "pysam": ["python", "cython", "cmake", "zlib"]}
+{"libnetcdf": ["cmake", "zlib", "hdf5", "curl"], "pysam": ["python", "cython", "cmake", "zlib"]}

--- a/package_tree.js
+++ b/package_tree.js
@@ -1,0 +1,1 @@
+{"libnetcdf": ["curl", "cmake", "hdf5", "zlib"], "pysam": ["python", "cython", "cmake", "zlib"]}

--- a/special_cases/ncurses/run_test.py
+++ b/special_cases/ncurses/run_test.py
@@ -1,0 +1,1 @@
+import curses


### PR DESCRIPTION
Adds a new CLI item for help with submission of packages from the jsonified package tree created in `python build2.py ./ split -s package_tree.js`. The name of the output of the split file must be `package_tree.js` so that anaconda build includes it among the dependency files (it check git ls-files and this PR adds it to the ls-files output).

Using it:
- This is how I test it on a local OSX worker that is listening to psteinberg/abc queue

```
python build2.py ./ submit -json-file-key package_tree.js  libnetcdf   -user psteinberg -queue abc -platforms osx-64
```

It says:
- open the package_tree.js file and build the packages in the libnetcdf list as well as libnetdf
- create the package under psteinberg username (can be your personal or conda-team)
- build on the -queue named, here abc, but 'build_recipes' by default
- build on the osx-64 platforms, other choices are linux-64, win-64

To submit all packages named in package_tree.js, do:

```
python build2.py ./ submit -full-json package_tree.js -user psteinberg -queue abc
```

Either command accepts a -dry argument for dry run.

Example command and output:

```
$ python build2.py ./ submit -json-file-key package_tree.js  libnetcdf   -user psteinberg -queue abc -platforms osx-64
Running build2.py with args of Namespace(dry=False, full_json=None, json_file_key=['package_tree.js', 'libnetcdf'], path='./', platforms=['osx-64'], queue='abc', user='psteinberg')

-------------------------------
Check to see if psteinberg/protoci-libnetcdf exists: ['anaconda', 'build', 'list-all', 'psteinberg/protoci-libnetcdf']
Using anaconda-server api site http://api.anaconda.org
Getting builds:
        Build # |          Status |        Platform |          Engine |             Env
--------------- + --------------- + --------------- + --------------- + ---------------
            3.0 |         running |          osx-64 |          python |            None
            2.0 |         failure |          osx-64 |          python |            None
            1.0 |           error |          osx-64 |          python |            None

prepare to submit ['anaconda', 'build', 'submit', './', '--queue', 'psteinberg/abc']
TAIL:        binstar-build tail -f psteinberg/protoci-libnetcdf 4
```
