### PR TITLE
avoid error when no changes to commit in target path's git

### DIFF
--- a/build2.py
+++ b/build2.py
@@ -405,7 +405,10 @@ def pre_submit_clean_up(args):
     print('Make a scratch git branch in', os.path.abspath(args.path))
     subprocess.check_output(['git', 'checkout', '-b', branch_name], cwd=args.path)
     subprocess.check_output(['git', 'add', build2_in_other_dir, package_tree_file], cwd=args.path)
-    subprocess.check_output(['git', 'commit', '-m', 'commit build2.py and the package json for anaconda-build'], cwd=args.path)
+    print(subprocess.Popen(
+          ['git', 'commit', '-m',
+          'commit build2.py and the package json for anaconda-build'],
+          cwd=args.path).communicate())
 
 
 def submit_helper(args):


### PR DESCRIPTION
When submitting packages with `build2.py` and in the part of the script that does a `git commit` in the submitted dir, I was encountering an error with `subprocess.check_output` if there were no diffs to commit.  (Git returns non-zero exit code if there are no changes to commit).  I fixed this issue by converting that `check_output` to a `Popen` call.
