### PR TITLE
Dirty nodes

### DIFF
--- a/build2.py
+++ b/build2.py
@@ -172,7 +172,7 @@ def dirty(graph):
     """
     Return a set of all dirty nodes in the graph
     """
-    return {n for n in graph.node if getattr(n, 'dirty', False) == True}
+    return {n for n, v in graph.node.items() if v.get('dirty', False)}
 
 def successors_iter(g, s, nodes):
     for s in g.successors(s):
@@ -226,12 +226,21 @@ def build_order(graph, packages, level=0):
     Builds a temporary graph of relevant nodes and returns it topological sort.
     
     Relevant nodes selected in a breadth first traversal sourced at each pkg in packages.
+    
+    Values expected for packages is one of None, sequence:
+       None: build the whole graph
+       empty sequence: build nodes marked dirty
+       non-empty sequence: build nodes in sequence
     '''
 
     if packages is None:
         tmp_global = graph.subgraph(graph.nodes())
     else:
-        packages = set(packages)
+        # sequence
+        if packages:
+            packages = set(packages)
+        else:
+            packages = dirty(graph)
         tmp_global = graph.subgraph(packages)
 
         if level > 0:

--- a/build2.py
+++ b/build2.py
@@ -14,7 +14,6 @@ import networkx as nx
 import sys
 
 
-
 from conda_build.metadata import parse, MetaData
 
 CONDA_BUILD_CACHE=os.environ.get("CONDA_BUILD_CACHE")
@@ -206,7 +205,10 @@ def split_graph(g, targetnum, split_file):
 
 def build_order(graph, packages, level=0):
     '''
-    Assumes that packages are in graph
+    Assumes that packages are in graph.
+    Builds a temporary graph of relevant nodes and returns it topological sort.
+    
+    Relevant nodes selected in a breadth first traversal sourced at each pkg in packages.
     '''
 
     if packages is None:
@@ -233,14 +235,6 @@ def build_order(graph, packages, level=0):
         tmp_global.node[n] = graph.node[n]
 
     return tmp_global, nx.topological_sort(tmp_global, reverse=True)
-
-
-def check_built(package):
-    '''Check to see if package is already built'''
-    print("checking if package exists")
-    if os.path.exists(os.path.join(CONDA_BUILD_CACHE, package.pkg_fn())):
-        return True
-    return False
 
 
 def make_deps(graph, package, dry=False, extra_args='', level=0, autofail=True):

--- a/build2.py
+++ b/build2.py
@@ -168,11 +168,20 @@ def construct_graph(directory):
 
     return g
 
-def dirty(graph):
+def dirty(graph, implicit=True):
     """
-    Return a set of all dirty nodes in the graph
+    Return a set of all dirty nodes in the graph.
+    
+    These include implicit and explicit dirty nodes.
     """
-    return {n for n, v in graph.node.items() if v.get('dirty', False)}
+    # Reverse the edges to get true dependency
+    dirty_nodes = {n for n, v in graph.node.items() if v.get('dirty', False)}
+    if not implicit:
+        return dirty_nodes
+    
+    # Get implicitly dirty nodes (all of the packages that depend on a dirty package)
+    dirty_nodes.update(*map(set, (graph.predecessors(n) for n in dirty_nodes)))
+    return dirty_nodes
 
 def successors_iter(g, s, nodes):
     for s in g.successors(s):


### PR DESCRIPTION
Calculate dirty/changed recipes via git.  Passing an empty sequence to build_order will return correct build order for dirty nodes (both implicit and explicit).

While I think these changes should work in general, they have been minimally tested.
