### PR TITLE
add the start of a test suite for protoci itself

### DIFF
--- a/build_protoci.py
+++ b/build_protoci.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 """
 build_protoci.py creates conda packages of
 protoci for all operating systems and python versions.

--- a/build_protoci.py
+++ b/build_protoci.py
@@ -68,14 +68,16 @@ def build_protoci(input_args):
                 print(out)
             else:
                 print("Conversion ok for", file)
-                for dist_dir in dists:
-                    dist_dir = os.path.join(path, dist_dir)
+                for dist in dists:
+                    dist_dir = os.path.join(path, dist)
                     for dist_file in os.listdir(dist_dir):
+                        env = os.environ.copy()
+                        env['CONDA_PY'] = CONDA_PY
                         proc = Popen(['anaconda', 'upload',
                                '--user', input_args.user,
                                os.path.abspath(os.path.join(dist_dir, dist_file)),
                                '--force',],
-                               cwd='.')
+                               cwd=path)
                         if proc.wait():
                             print('Failed on anaconda upload')
                             sys.exit(proc.poll())

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: protoci
-  version: 0.0.31
+  version: 0.0.32
 
 source:
-  git_rev: 0.0.31
+  git_rev: 0.0.32
   git_url: https://github.com/ContinuumIO/ProtoCI
 
 build:
@@ -18,6 +18,7 @@ requirements:
     - jinja2
     - psutil
     - pycosat
+    - pytest
   run:
     - networkx
     - requests
@@ -27,6 +28,7 @@ requirements:
     - jinja2
     - psutil
     - pycosat
+    - pytest
 about:
   summary: Helps with building conda packages in anaconda-build.
 

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,17 @@ def find_package_data():
 
 setup(
     name='protoci',
-    version='0.0.31',
+    version='0.0.32',
     author='Continuum Analytics',
     author_email='psteinberg@continuum.io',
     url='http://github.com/ContinuumIO/protoci',
     packages=['protoci'],
     include_package_data=True,
     package_data={'protoci': ['protoci/data/*',] + find_package_data()},
-    install_requires=['networkx',
+    install_requires=['networkx', 'setuptools',
                       'PyYAML', 'requests',
-                      'jinja2', 'psutil'],
+                      'jinja2', 'psutil',
+                      'pytest','pycosat'],
     zip_safe=False,
     entry_points={
       'console_scripts': [


### PR DESCRIPTION
This PR adds a test that:
- clones conda-recipes repo
- makes a change in matplotlib package meta.yaml there
- commits the change
- runs `protoci-difference-build` there
- confirms that a test of `matplotlib` has been triggered directly and `seaborn` is being tested as indirectly affected.
